### PR TITLE
replace confusing gitpod url with doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ To start using this project in Gitpod, follow these steps:
 
 1. Fork the repository by clicking the "Fork" button in the top right corner of the repository page. This creates a copy of the repository in your GitHub account.
 
-2. Click the following link to open this repository in Gitpod: [Open in Gitpod](https://gitpod.io/#https://github.com/shesharpnl/hackathon-2023.data-analysis.base-example)
+2. Add `https://gitpod.io/#` to beginning of the current url to open this repository in Gitpod, e.g.: https://gitpod.io/#https://github.com/shesharpnl/hackathon-2023.data-analysis.base-example.
 
 3. Gitpod will open the project in a new workspace, providing you with an integrated development environment (IDE) for writing and running code.
 


### PR DESCRIPTION
If you follow the instructions and fork the repository, the link for [Open in Gitpod] no longer works. Since the link is currently hidden, it's not immediately obvious why it doesn't work.

My suggestion instead shows the reader how to open any repository in Gitpod. Open to other suggestions/rewording!